### PR TITLE
Update API url

### DIFF
--- a/MMM-PilotWX.js
+++ b/MMM-PilotWX.js
@@ -39,7 +39,7 @@ Module.register('MMM-PilotWX', {
 
     // Set locale.
     ;(this.url =
-      'https://aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&stationString=' +
+      'https://aviationweather.gov/api/data/dataserver?dataSource=metars&requestType=retrieve&format=xml&stationString=' +
       this.config.ICAO +
       '&hoursBeforeNow=1'),
       (this.url =


### PR DESCRIPTION
The previous API URL now results in a 403 error. Updated the API url based on the API documentation provided by AviationWeather: https://aviationweather.gov/data/api/#/Dataserver/dataserverMetars